### PR TITLE
added GitHub workflow to publish to NPM's public registry

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,7 +21,7 @@ jobs:
         tag_name: "v%s"
         tag_message: "v%s"
         commit_pattern: "^Release (\\S+)"
-        workspace: ".codedoc"
+        workspace: "."
       env: # Documentation of environment variables https://github.com/marketplace/actions/publish-to-npm#environment-variables
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # Must be set in repo settings

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+# Based on template copied from https://github.com/marketplace/actions/publish-to-npm#usage
+name: npm-publish
+on:
+  push:
+    branches:
+      - master
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@master
+    - name: Set up Node.js
+      uses: actions/setup-node@master
+      with:
+        node-version: 12.0.0
+    - name: Publish if version has been updated
+      uses: pascalgn/npm-publish-action@1.3.3
+      with: # Documentation of inputs https://github.com/marketplace/actions/publish-to-npm#inputs
+        tag_name: "v%s"
+        tag_message: "v%s"
+        commit_pattern: "^Release (\\S+)"
+        workspace: ".codedoc"
+      env: # Documentation of environment variables https://github.com/marketplace/actions/publish-to-npm#environment-variables
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # Must be set in repo settings

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/setup-node@master
       with:
         node-version: 12.0.0
+    - name: Build the package
+      run: npm run build
     - name: Publish if version has been updated
       uses: pascalgn/npm-publish-action@1.3.3
       with: # Documentation of inputs https://github.com/marketplace/actions/publish-to-npm#inputs


### PR DESCRIPTION
Resolves #20

This PR adds a GitHub workflow to automate the publishing to NPM's public registry.

I copied [this template](https://github.com/marketplace/actions/publish-to-npm#usage), and then made the following modifications.
- Added three links to documentation.
- Changed the value of `node-version` from `10.0.0` to `12.0.0` (since it seems like a good idea to use a newer version).
- Changed the value of `workspace` from `"."` to `".codedoc"` (since this value gives the path to the `package.json` file).

How this works:
- Executed when the `master` branch contains a commit with a message that matches the pattern given by the value of `commit_pattern`.  An example is `Release 1.2.3`.
- Creates a tag with a name and message matching the patterns respectively given by the values of `tag_name` and `tag_message`.  Continuing the previous example, the name and message would both be `v1.2.3`.
- Publishes to NPM's public registry.

You have to do one thing on your end, which is to [create a new GitHub secret](https://github.com/CONNECT-platform/coding-blog-plugin/settings/secrets/new) with the name `NPM_AUTH_TOKEN` and with a value of a personal authentication token for your account on [npmjs.com](https://www.npmjs.com/).