### PR TITLE
Adds npm install steps to publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,23 +9,21 @@ jobs:
     name: npm-publish
     runs-on: ubuntu-latest
     steps:
-    - name: To be completed
-      run: echo "This workflow needs to be completed"
-    #- name: Checkout repository
-    #  uses: actions/checkout@master
-    #- name: Set up Node.js
-    #  uses: actions/setup-node@master
-    #  with:
-    #    node-version: 12.0.0
-    #- name: Build the package
-    #  run: npm run build
-    #- name: Publish if version has been updated
-    #  uses: pascalgn/npm-publish-action@1.3.3
-    #  with: # Documentation of inputs https://github.com/marketplace/actions/publish-to-npm#inputs
-    #    tag_name: "v%s"
-    #    tag_message: "v%s"
-    #    commit_pattern: "^Release (\\S+)"
-    #    workspace: "."
-    #  env: # Documentation of environment variables https://github.com/marketplace/actions/publish-to-npm#environment-variables
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
-    #    NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # Must be set in repo settings
+    - name: Checkout repository
+      uses: actions/checkout@master
+    - name: Set up Node.js
+      uses: actions/setup-node@master
+      with:
+        node-version: 12.0.0
+    - name: Build the package
+      run: npm run build
+    - name: Publish if version has been updated
+      uses: pascalgn/npm-publish-action@1.3.3
+      with: # Documentation of inputs https://github.com/marketplace/actions/publish-to-npm#inputs
+        tag_name: "v%s"
+        tag_message: "v%s"
+        commit_pattern: "^Release (\\S+)"
+        workspace: "."
+      env: # Documentation of environment variables https://github.com/marketplace/actions/publish-to-npm#environment-variables
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # Must be set in repo settings

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/setup-node@master
       with:
         node-version: 12.0.0
+    - name: Install dependencies in .codedoc
+      run: cd .codedoc && npm install
+    - name: Install dependencies in .
+      run: npm install
     - name: Build the package
       run: npm run build
     - name: Publish if version has been updated


### PR DESCRIPTION
The publish workflow needs install steps.  After I added these install steps, [the workflow passed for me](https://github.com/TysonMN/coding-blog-plugin/runs/1117865471?check_suite_focus=true).  Still not sure if it will successfully publish a new version when it is supposed to.